### PR TITLE
PLATO-130: Pass along ajax headers when loading thumbnails in reference strip

### DIFF
--- a/src/referencestrip.js
+++ b/src/referencestrip.js
@@ -449,7 +449,9 @@ function loadPanels( strip, viewerSize, scroll ) {
                 showSequenceControl:    false,
                 immediateRender:        true,
                 blendTime:              0,
-                animationTime:          0
+                animationTime:          0,
+                loadTilesWithAjax:      strip.viewer.loadTilesWithAjax,
+                ajaxHeaders:            strip.viewer.ajaxHeaders
             } );
 
             miniViewer.displayRegion           = $.makeNeutralElement( "div" );


### PR DESCRIPTION
When loading the reference strip, openseadragon attempts to create "miniViewers" for each thumbnail which are really full fledged viewers with just a small set of configs passed to them. 
https://github.com/ithaka/openseadragon/blob/19d66892edda4637a8e22e95b091ba4a12aee3b9/src/referencestrip.js#L441

When we provide the `loadTilesWithAjax` and `ajaxHeaders` configs to our main viewer, the ajax calls involved in loading the main image work correct, HOWEVER the `miniViewers` do not get the configs applied to them. For our case, this causes the thumbnails not to load.

This PR ensures the `miniViewer` get the necessary ajax configs we need for each of the thumbnail images to load.