### PR TITLE
PLATO-266: Use `full` instead of `max` in urls to support our iiif 2.0 server

### DIFF
--- a/src/iiiftilesource.js
+++ b/src/iiiftilesource.js
@@ -370,7 +370,7 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
             if ( isv1 || levelWidth !== this.width ) {
                 iiifSize = levelWidth + ",";
             } else {
-                iiifSize = "max";
+                iiifSize = "full";
             }
             iiifRegion = 'full';
         } else {
@@ -385,7 +385,7 @@ $.extend( $.IIIFTileSource.prototype, $.TileSource.prototype, /** @lends OpenSea
             }
             iiifSizeW = Math.ceil( iiifTileW * scale );
             if ( (!isv1) && iiifSizeW === this.width ) {
-                iiifSize = "max";
+                iiifSize = "full";
             } else {
                 iiifSize = iiifSizeW + ",";
             }


### PR DESCRIPTION
Resolves [PLATO-266](https://jira.jstor.org/browse/PLATO-266)

Replaces `max` with `full` so OSD sends urls that our IIIF 2.0 server can understand. 

https://iiif.io/api/image/2.1/#size
https://iiif.io/api/image/2.0/#size